### PR TITLE
refactor(#39): update cmv.py architecture

### DIFF
--- a/modules/cmv.py
+++ b/modules/cmv.py
@@ -1,5 +1,81 @@
 from modules.types import Coordinate, Parameters
 
+# Helper functions
+def check_clic_1() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_2() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_3() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_4() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_5() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_6() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_7() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_8() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_9() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_10() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_11() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_12() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_13() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_14() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+def check_lic_14() -> bool:
+    # TODO: Update the function signature and implementation
+    return False
+
+# Main function
 def get_cmv(num_points: int, points: list[Coordinate], parameters: Parameters) -> list[bool]:
-    # TODO: To be implemented
-    return [False] * 15
+    return [
+        check_clic_1(),
+        check_lic_2(),
+        check_lic_3(),
+        check_lic_4(),
+        check_lic_5(),
+        check_lic_6(),
+        check_lic_7(),
+        check_lic_8(),
+        check_lic_9(),
+        check_lic_10(),
+        check_lic_11(),
+        check_lic_12(),
+        check_lic_13(),
+        check_lic_14(),
+    ]


### PR DESCRIPTION
Closes #39.

This PR updates `cmv.py` such that it better reflects the architecture, i.e. we should be invoking 15 sub-functions from the main CMV function. 

No unit tests are included, because this is a trivial change. There is also no way for us to test the main CMV function, since it only invokes and returns the results of 15 sub-functions. We will, however, be adding unit tests for the sub-functions as they get implemented.